### PR TITLE
fix(user-story): update this.userStories before committing deletion

### DIFF
--- a/src/js/models/user-story.js
+++ b/src/js/models/user-story.js
@@ -23,7 +23,8 @@ class UserStory {
 	}
 
 	deleteAll() {
-		this._commit([]);
+		this.userStories = [];
+		this._commit(this.userStories);
 		localStorage.removeItem('userStories');
 	}
 
@@ -43,6 +44,7 @@ class UserStory {
 	_commit(userStories) {
 		this.onUserStoryListChanged(userStories);
 		localStorage.setItem('userStories', JSON.stringify(userStories));
+		this.onUserStoryListChanged(userStories);
 	}
 
 	bindUserStoryChanged(callback) {


### PR DESCRIPTION
On Chrome and Safari, the previous code would cause only shallowly delete user-stories.
Therefore when creating a new user-story, the previously deleted ones would reappear.